### PR TITLE
Added suppor multiple secrets for gateway

### DIFF
--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -1131,7 +1131,7 @@ for NAMESPACE in $NAMESPACE_LIST; do
 
                 #POST XML to gateway, start error report creation
                 admin_password="admin"
-                secret_name=`kubectl get secrets -n $NAMESPACE | egrep 'admin-secret|gw-admin' | awk '{print $1}'`
+                secret_name=`kubectl get pods -n $NAMESPACE ${pod} -o jsonpath='{range .spec.volumes[*]}{.secret.secretName}{"\n"}{end}' | grep admin`
                 if [[ ${#secret_name} -gt 0 ]]; then
                     admin_password=`kubectl get secret $secret_name -o jsonpath='{.data.password}' | base64 -d`
                 fi


### PR DESCRIPTION
Hi team,

For multiple gateway clusters with different admin secrets the output.error file is empty. This causes the error-report.0000000XXXXXXX.txt.gz file not to be generated.

With this PR the exactly admin secret name is extracted from the POD.

It has been tested in our environment where we have configured up to 3 gateway clusters.

Please your support.